### PR TITLE
Add Config Index

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,13 +6,13 @@
 #psiViewerPluginVersion = 183.2153
 #symfonyPluginVersion = 0.16.167
 
-ideaVersion = IU-2018.2.4
-phpPluginVersion = 182.4323.68
+ideaVersion = IU-2019.1
+phpPluginVersion = 191.6183.95
 toolboxPluginVersion = 0.4.6
-twigPluginVersion = 182.3458.35
-annotationPluginVersion = 5.3
-psiViewerPluginVersion = 182.2757.2
-symfonyPluginVersion = 0.17.169
+twigPluginVersion = 191.6183.95
+annotationPluginVersion = 5.3.3
+psiViewerPluginVersion = 191.4212
+symfonyPluginVersion = 0.17.172
 
 #ideaVersion = IU-2018.1.4
 #phpPluginVersion = 181.5087.24

--- a/src/main/java/de/espend/idea/shopware/completion/ShopwarePhpCompletion.java
+++ b/src/main/java/de/espend/idea/shopware/completion/ShopwarePhpCompletion.java
@@ -5,15 +5,18 @@ import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.icons.AllIcons;
 import com.intellij.patterns.PlatformPatterns;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.psi.xml.XmlTag;
 import com.intellij.util.ProcessingContext;
+import com.intellij.util.indexing.FileBasedIndex;
 import com.jetbrains.php.PhpIcons;
 import com.jetbrains.php.PhpIndex;
 import com.jetbrains.php.lang.parser.PhpElementTypes;
 import com.jetbrains.php.lang.psi.elements.*;
 import de.espend.idea.shopware.ShopwarePluginIcons;
 import de.espend.idea.shopware.ShopwareProjectComponent;
+import de.espend.idea.shopware.index.ConfigIndex;
 import de.espend.idea.shopware.util.ConfigUtil;
 import de.espend.idea.shopware.util.ShopwareUtil;
 import de.espend.idea.shopware.util.ThemeUtil;
@@ -21,6 +24,8 @@ import fr.adrienbrault.idea.symfony2plugin.Symfony2Icons;
 import fr.adrienbrault.idea.symfony2plugin.util.MethodMatcher;
 import icons.ShopwareIcons;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
 
 /**
  * @author Daniel Espendiller <daniel@espendiller.net>
@@ -66,6 +71,12 @@ public class ShopwarePhpCompletion extends CompletionContributor{
                         for(String type: ShopwareUtil.PLUGIN_CONFIGS) {
                             result.addElement(LookupElementBuilder.create(type).withIcon(Symfony2Icons.CONFIG_VALUE));
                         }
+
+                        for (Set<String> configValues : FileBasedIndex.getInstance().getValues(ConfigIndex.KEY, "all", GlobalSearchScope.allScope(originalPosition.getProject()))) {
+                            for (String config : configValues) {
+                                result.addElement(LookupElementBuilder.create(config).withIcon(ShopwareIcons.SHOPWARE));
+                            }
+                        }
                     }
 
                     if(new MethodMatcher.StringParameterRecursiveMatcher(originalPosition.getContext(), 0).withSignature("\\Shopware\\Models\\Config\\Form", "setElement").match() != null) {
@@ -97,7 +108,6 @@ public class ShopwarePhpCompletion extends CompletionContributor{
                             result.addElement(LookupElementBuilder.create(type).withIcon(ShopwarePluginIcons.SHOPWARE));
                         }
                     }
-
                 }
             }
         );

--- a/src/main/java/de/espend/idea/shopware/completion/SmartyFileCompletionProvider.java
+++ b/src/main/java/de/espend/idea/shopware/completion/SmartyFileCompletionProvider.java
@@ -20,12 +20,14 @@ import com.jetbrains.smarty.lang.SmartyTokenTypes;
 import com.jetbrains.smarty.lang.psi.SmartyTag;
 import de.espend.idea.shopware.ShopwarePluginIcons;
 import de.espend.idea.shopware.ShopwareProjectComponent;
+import de.espend.idea.shopware.index.ConfigIndex;
 import de.espend.idea.shopware.index.SmartyBlockStubIndex;
 import de.espend.idea.shopware.lookup.TemplateLookupElement;
 import de.espend.idea.shopware.util.*;
 import fr.adrienbrault.idea.symfony2plugin.Symfony2Icons;
 import fr.adrienbrault.idea.symfony2plugin.stubs.SymfonyProcessors;
 import fr.adrienbrault.idea.symfony2plugin.templating.util.TwigTypeResolveUtil;
+import icons.ShopwareIcons;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -288,6 +290,12 @@ public class SmartyFileCompletionProvider extends CompletionContributor  {
 
                     for(String config: ShopwareUtil.PLUGIN_CONFIGS) {
                         result.addElement(LookupElementBuilder.create(config).withIcon(Symfony2Icons.CONFIG_VALUE));
+                    }
+
+                    for (Set<String> configValues : FileBasedIndex.getInstance().getValues(ConfigIndex.KEY, "all", GlobalSearchScope.allScope(parameters.getOriginalPosition().getProject()))) {
+                        for (String config : configValues) {
+                            result.addElement(LookupElementBuilder.create(config).withIcon(ShopwareIcons.SHOPWARE));
+                        }
                     }
 
                 }

--- a/src/main/java/de/espend/idea/shopware/index/ConfigIndex.java
+++ b/src/main/java/de/espend/idea/shopware/index/ConfigIndex.java
@@ -1,0 +1,193 @@
+package de.espend.idea.shopware.index;
+
+import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiRecursiveElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.util.ObjectUtils;
+import com.intellij.util.containers.HashSet;
+import com.intellij.util.indexing.*;
+import com.intellij.util.io.DataExternalizer;
+import com.intellij.util.io.EnumeratorStringDescriptor;
+import com.intellij.util.io.KeyDescriptor;
+import com.jetbrains.php.lang.PhpFileType;
+import com.jetbrains.php.lang.psi.elements.*;
+import com.jetbrains.smarty.SmartyFile;
+import com.jetbrains.smarty.SmartyFileType;
+import de.espend.idea.shopware.util.ConfigUtil;
+import fr.adrienbrault.idea.symfony2plugin.Symfony2ProjectComponent;
+import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer.StringSetDataExternalizer;
+import fr.adrienbrault.idea.symfony2plugin.util.PhpElementsUtil;
+import gnu.trove.THashMap;
+import org.apache.commons.lang.StringUtils;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Soner Sayakci <s.sayakci@gmail.com>
+ */
+public class ConfigIndex extends FileBasedIndexExtension<String, Set<String>> {
+
+    public static final ID<String, Set<String>> KEY = ID.create("de.espend.idea.shopware.config_index");
+    private final KeyDescriptor<String> myKeyDescriptor = new EnumeratorStringDescriptor();
+
+    private static final Set<String> METHODS = new HashSet<String>() {{
+        add("get");
+        add("offsetGet");
+    }};
+
+    @NotNull
+    @Override
+    public ID<String, Set<String>> getName() {
+        return KEY;
+    }
+
+    @NotNull
+    @Override
+    public DataIndexer<String, Set<String>, FileContent> getIndexer() {
+        return inputData -> {
+            Map<String, Set<String>> map = new THashMap<>();
+            map.putIfAbsent("all", new java.util.HashSet<>());
+
+            FileType fileType = inputData.getFileType();
+            if (fileType == SmartyFileType.INSTANCE && inputData.getPsiFile() instanceof SmartyFile) {
+                for (String name : ConfigUtil.getConfigsInFile((SmartyFile) inputData.getPsiFile())) {
+                    map.get("all").add(name);
+                }
+
+            } else {
+                PsiFile psiFile = inputData.getPsiFile();
+                if(!Symfony2ProjectComponent.isEnabled(psiFile.getProject())) {
+                    return Collections.emptyMap();
+                }
+
+                psiFile.accept(new MyPsiRecursiveElementWalkingVisitor(map));
+            }
+
+
+            return map;
+        };
+    }
+
+    @NotNull
+    @Override
+    public KeyDescriptor<String> getKeyDescriptor() {
+        return this.myKeyDescriptor;
+    }
+
+    @NotNull
+    @Override
+    public DataExternalizer<Set<String>> getValueExternalizer() {
+        return new StringSetDataExternalizer();
+    }
+
+    @NotNull
+    @Override
+    public FileBasedIndex.InputFilter getInputFilter() {
+        return file -> file.getFileType() == PhpFileType.INSTANCE || file.getFileType() == SmartyFileType.INSTANCE;
+    }
+
+    @Override
+    public boolean dependsOnFileContent() {
+        return true;
+    }
+
+    @Override
+    public int getVersion() {
+        return 2;
+    }
+
+    private class MyPsiRecursiveElementWalkingVisitor extends PsiRecursiveElementVisitor {
+
+        private final Map<String, Set<String>> map;
+
+        MyPsiRecursiveElementWalkingVisitor(@NotNull Map<String, Set<String>> map) {
+            this.map = map;
+        }
+
+        @Override
+        public void visitElement(PsiElement element) {
+            if(!(element instanceof Parameter)) {
+                super.visitElement(element);
+                return;
+            }
+
+            ClassReference classReference = null;
+
+            for(PsiElement loopElement : element.getChildren()) {
+                ClassReference classReferenceLoop = ObjectUtils.tryCast(loopElement, ClassReference.class);
+                if(classReferenceLoop == null) {
+                    return;
+                }
+
+                String fqn = StringUtils.stripStart(classReferenceLoop.getFQN(), "\\");
+                if(fqn.equals("Shopware_Components_Config")) {
+                    classReference = classReferenceLoop;
+                    break;
+                }
+            }
+
+            if (classReference == null) {
+                return;
+            }
+
+            Parameter parentOfType = PsiTreeUtil.getParentOfType(classReference, Parameter.class);
+            if(parentOfType == null) {
+                return;
+            }
+
+            final String name = parentOfType.getName();
+
+            Method method = PsiTreeUtil.getParentOfType(classReference, Method.class);
+            if(method == null) {
+                return;
+            }
+
+            method.accept(new MyMethodVariableVisitor(name, map));
+
+            super.visitElement(element);
+        }
+    }
+
+    private class MyMethodVariableVisitor extends PsiRecursiveElementVisitor {
+
+        @NotNull
+        private final String name;
+
+        @NotNull
+        private final Map<String, Set<String>> result;
+
+        MyMethodVariableVisitor(@NotNull String name, @NotNull Map<String, Set<String>> result) {
+            this.name = name;
+            this.result = result;
+        }
+
+        @Override
+        public void visitElement(PsiElement element) {
+            if(!(element instanceof Variable) || !name.equals(((Variable) element).getName())) {
+                super.visitElement(element);
+                return;
+            }
+
+            MethodReference methodReference = ObjectUtils.tryCast(element.getParent(), MethodReference.class);
+            if(methodReference == null || !METHODS.contains(methodReference.getName())) {
+                super.visitElement(element);
+                return;
+            }
+
+            String value = PhpElementsUtil.getFirstArgumentStringValue(methodReference);
+            if(value == null) {
+                super.visitElement(element);
+                return;
+            }
+
+            result.get("all").add(value);
+
+            super.visitElement(element);
+        }
+    }
+}

--- a/src/main/java/de/espend/idea/shopware/util/HookSubscriberUtil.java
+++ b/src/main/java/de/espend/idea/shopware/util/HookSubscriberUtil.java
@@ -24,8 +24,6 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class HookSubscriberUtil {
 
-    public static Set<String> NOTIFY_EVENTS = ContainerUtil.newHashSet();
-
     final private static Set<String> CORE_CLASSES = new HashSet<String>() {{
         addAll(Arrays.asList("sCms", "sCore", "sAdmin", "sOrder", "sBasket", "sExport", "sSystem", "sArticles", "sMarketing", "sCategories", "sCategories", "sNewsletter", "sConfigurator", "sRewriteTable"));
     }};

--- a/src/main/java/de/espend/idea/shopware/util/ShopwareFQDN.java
+++ b/src/main/java/de/espend/idea/shopware/util/ShopwareFQDN.java
@@ -5,4 +5,5 @@ public class ShopwareFQDN {
     public static String PREFIX_FILESYSTEM = "\\Shopware\\Components\\Filesystem\\PrefixFilesystem";
     public static String PLUGIN_LOGGER_COMPILERPASS = "\\Shopware\\Components\\DependencyInjection\\Compiler\\PluginLoggerCompilerPass";
     public static String SHOPWARE_LOGGER = "\\Shopware\\Components\\Logger";
+    public static String SHOPWARE_CONFIG = "\\Shopware_Components_Config";
 }

--- a/src/main/java/de/espend/idea/shopware/util/SmartyPattern.java
+++ b/src/main/java/de/espend/idea/shopware/util/SmartyPattern.java
@@ -202,6 +202,29 @@ public class SmartyPattern {
         );
     }
 
+    /**
+     * {tag attribute="<caret>"}
+     */
+    public static ElementPattern<PsiElement> getTagAttributePattern(@NotNull String tag, @NotNull String attribute, boolean fallback) {
+        if (fallback) {
+            return getTagAttributePattern(tag, attribute);
+        }
+
+        return PlatformPatterns.psiElement(SmartyTokenTypes.IDENTIFIER)
+                .afterLeafSkipping(
+                PlatformPatterns.or(
+                        PlatformPatterns.psiElement(SmartyTokenTypes.EQ),
+                        PlatformPatterns.psiElement(SmartyTokenTypes.WHITE_SPACE),
+                        PlatformPatterns.psiElement(SmartyTokenTypes.SINGLE_QUOTE),
+                        PlatformPatterns.psiElement(SmartyTokenTypes.DOUBLE_QUOTE)
+                ),
+                PlatformPatterns.psiElement(SmartyTokenTypes.IDENTIFIER).withText(attribute)
+        )
+                .withParent(
+                        PlatformPatterns.psiElement(SmartyCompositeElementTypes.TAG).withText(PlatformPatterns.string().startsWith("{" + tag))
+                );
+    }
+
     public static ElementPattern<PsiElement> getNamespacePattern() {
         return getTagAttributePattern("s", "namespace");
     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -111,6 +111,7 @@
       <fileBasedIndex implementation="de.espend.idea.shopware.index.EventConfigGoToIndex"/>
       <fileBasedIndex implementation="de.espend.idea.shopware.index.InitResourceServiceIndex"/>
       <fileBasedIndex implementation="de.espend.idea.shopware.index.SnippetIndex"/>
+      <fileBasedIndex implementation="de.espend.idea.shopware.index.ConfigIndex"/>
 
       <lang.foldingBuilder language="JavaScript" implementationClass="de.espend.idea.shopware.folding.JavascriptFoldingBuilder"/>
 

--- a/src/test/java/de/espend/idea/shopware/tests/index/ConfigIndexTest.java
+++ b/src/test/java/de/espend/idea/shopware/tests/index/ConfigIndexTest.java
@@ -1,0 +1,41 @@
+package de.espend.idea.shopware.tests.index;
+
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.util.indexing.FileBasedIndex;
+import de.espend.idea.shopware.index.ConfigIndex;
+import de.espend.idea.shopware.tests.ShopwareLightCodeInsightFixtureTestCase;
+
+import java.util.Set;
+
+public class ConfigIndexTest extends ShopwareLightCodeInsightFixtureTestCase {
+    public void setUp() throws Exception {
+        super.setUp();
+        myFixture.copyFileToProject("sAdmin.php");
+    }
+
+    public String getTestDataPath() {
+        return "src/test/java/de/espend/idea/shopware/tests/index/fixtures";
+    }
+
+    public void testPropertyUsageInClass() {
+        assertIndexContains(ConfigIndex.KEY, "all");
+
+        for (Set<String> configValues : FileBasedIndex.getInstance().getValues(ConfigIndex.KEY, "all", GlobalSearchScope.allScope(this.getProject()))) {
+            for (String value: configValues) {
+                System.out.println(value);
+            }
+        }
+
+        assertIndexContainsKeyWithValue(ConfigIndex.KEY, "all", value ->
+                value.contains("sBASEFILE")
+        );
+
+        assertIndexContainsKeyWithValue(ConfigIndex.KEY, "all", value ->
+                value.contains("globalConfig")
+        );
+
+        assertIndexContainsKeyWithValue(ConfigIndex.KEY, "all", value ->
+                value.contains("variableConfig")
+        );
+    }
+}

--- a/src/test/java/de/espend/idea/shopware/tests/index/fixtures/sAdmin.php
+++ b/src/test/java/de/espend/idea/shopware/tests/index/fixtures/sAdmin.php
@@ -1,0 +1,30 @@
+<?php
+
+class Shopware {
+    /**
+     * @return \Shopware_Components_Config
+     */
+    public function Config()
+    {
+
+    }
+}
+
+function Shopware(){
+    return new Shopware();
+}
+
+class sAdmin {
+    /** @var Shopware_Components_Config */
+    private $config;
+
+    public function foo()
+    {
+        $this->config->get('sBASEFILE');
+        Shopware()->Config()->get('globalConfig');
+
+        $config = $this->config;
+
+        $config->get('variableConfig');
+    }
+}


### PR DESCRIPTION
Indexes all {config name=foo} or Shopware()->Config()->get('foo'); to show it as autocomplete.

The Indexer in this Pull Request does not index some results like this [here](https://github.com/shopware/shopware/blob/5.5/engine/Shopware/Core/sAdmin.php#L1284).

I tried many things loop over all children to find the Config and much more without success. I have no idea's anymore 🙈 

[PSI Viewer](https://i.imgur.com/ID584xI.png). Have you a idea how solve this issue?

## Images
![Img 1](https://i.imgur.com/TuqFSTr.png)
![Img 2](https://i.imgur.com/2YQLBhz.png)